### PR TITLE
[Feature] Add --pull and --build options

### DIFF
--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -21,10 +21,12 @@ Options:
 	--ros=<distro_name>     ROS distribution name
 	--config=<file_name>    World configuration file
 	--pr=<number>           Branch to compile from based on Pull Request #
-	--dev                   Install Gazebo development libraries
-	--source                Build Gazebo/ROS from source
+	--dev                   Install development libraries
+	--source                Set up development environment and dependencies
+	--pull                  Pull all the official source code repositories
+	--build                 Compile and install everything from source
 	--yes                   Confirm selection of unofficial ROS + Gazebo version
-	--nvidia                Select nvidia as the runtime for the container.
+	--nvidia                Select nvidia as the runtime for the container
 
 """
 

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -7,6 +7,7 @@ Usage:
 				[<config> | --config=<file_name>]
 				[<pr> | --pr=<number>]
 				[--dev | --source]
+                [--pull]
 				[--yes]
 				[--nvidia]
 	gzdev spawn -h | --help
@@ -57,13 +58,14 @@ def normalize_args(args):
     confirm = args["--yes"]
     nvidia = args["--nvidia"]
     source = args["--source"]
+    pull = args["--pull"]
 
     ros = ros.lower() if ros else None
     gzv = int(gzv) if gzv and gzv.isdecimal() else gzv
     if gzv == None and ros and ros in official_ros_gzv:
         gzv = official_ros_gzv[ros]
 
-    return gzv, ros, config, pr, confirm, nvidia, source
+    return gzv, ros, config, pr, confirm, nvidia, source, pull
 
 
 def error(msg):
@@ -72,7 +74,7 @@ def error(msg):
 
 
 def validate_input(args):
-    gzv, ros, config, pr, confirm, nvidia, source = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull = args
 
     if type(gzv) is int and (gzv <= 0 or gzv > max_gzv) or type(gzv) is str:
         error("ERROR: '%s' is not a valid Gazebo version number." % gzv)
@@ -100,7 +102,7 @@ def validate_input(args):
 
 
 def print_spawn_msg(args):
-    gzv, ros, config, pr, confirm, nvidia, source = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull = args
     gz_msg, ros_msg, config_msg, pr_msg = ("", "", "", "")
 
     if ros:
@@ -155,7 +157,7 @@ def write_log(log_path, log):
 
 
 def spawn_container(args):
-    gzv, ros, config, pr, confirm, nvidia, source = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull = args
     gzv = str(gzv)
     tag_name = "gz" + gzv
     build_args = {"GZV": gzv}
@@ -201,7 +203,10 @@ def spawn_container(args):
         xpra_volumes = {
             gzdev_path + 'gazebo': {'bind': '/mnt/gazebo', 'mode': 'rw'}
         }
-        cmd = None
+        if pull:
+            cmd = "gzrepos.sh"
+        else:
+            cmd = None
     else:
         cmd = "gzxpra.sh"
 

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -2,31 +2,31 @@
 # Licensed under the Apache License, Version 2.0
 """
 Usage:
-	gzdev spawn [<gzv> | --gzv=<number>]
-				[<ros> | --ros=<distro_name>]
-				[<config> | --config=<file_name>]
-				[<pr> | --pr=<number>]
-				[--dev | --source]
+    gzdev spawn [<gzv> | --gzv=<number>]
+                [<ros> | --ros=<distro_name>]
+                [<config> | --config=<file_name>]
+                [<pr> | --pr=<number>]
+                [--dev | --source]
                 [--pull]
                 [--build]
-				[--yes]
-				[--nvidia]
-	gzdev spawn -h | --help
-	gzdev spawn --version
+                [--yes]
+                [--nvidia]
+    gzdev spawn -h | --help
+    gzdev spawn --version
 
 Options:
-	-h --help               Show this screen
-	--version               Show gzdev's version
-	--gzv=<number>          Gazebo release version number
-	--ros=<distro_name>     ROS distribution name
-	--config=<file_name>    World configuration file
-	--pr=<number>           Branch to compile from based on Pull Request #
-	--dev                   Install development libraries
-	--source                Set up development environment and dependencies
-	--pull                  Pull all the official source code repositories
-	--build                 Compile and install everything from source
-	--yes                   Confirm selection of unofficial ROS + Gazebo version
-	--nvidia                Select nvidia as the runtime for the container
+    -h --help               Show this screen
+    --version               Show gzdev's version
+    --gzv=<number>          Gazebo release version number
+    --ros=<distro_name>     ROS distribution name
+    --config=<file_name>    World configuration file
+    --pr=<number>           Branch to compile from based on Pull Request #
+    --dev                   Install development libraries
+    --source                Set up development environment and dependencies
+    --pull                  Pull all the official source code repositories
+    --build                 Compile and install everything from source
+    --yes                   Confirm selection of unofficial ROS + Gazebo version
+    --nvidia                Select nvidia as the runtime for the container
 
 """
 

--- a/plugins/spawn.py
+++ b/plugins/spawn.py
@@ -8,6 +8,7 @@ Usage:
 				[<pr> | --pr=<number>]
 				[--dev | --source]
                 [--pull]
+                [--build]
 				[--yes]
 				[--nvidia]
 	gzdev spawn -h | --help
@@ -59,13 +60,14 @@ def normalize_args(args):
     nvidia = args["--nvidia"]
     source = args["--source"]
     pull = args["--pull"]
+    build = args["--build"]
 
     ros = ros.lower() if ros else None
     gzv = int(gzv) if gzv and gzv.isdecimal() else gzv
     if gzv == None and ros and ros in official_ros_gzv:
         gzv = official_ros_gzv[ros]
 
-    return gzv, ros, config, pr, confirm, nvidia, source, pull
+    return gzv, ros, config, pr, confirm, nvidia, source, pull, build
 
 
 def error(msg):
@@ -74,7 +76,7 @@ def error(msg):
 
 
 def validate_input(args):
-    gzv, ros, config, pr, confirm, nvidia, source, pull = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull, build = args
 
     if type(gzv) is int and (gzv <= 0 or gzv > max_gzv) or type(gzv) is str:
         error("ERROR: '%s' is not a valid Gazebo version number." % gzv)
@@ -102,7 +104,7 @@ def validate_input(args):
 
 
 def print_spawn_msg(args):
-    gzv, ros, config, pr, confirm, nvidia, source, pull = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull, build = args
     gz_msg, ros_msg, config_msg, pr_msg = ("", "", "", "")
 
     if ros:
@@ -157,7 +159,7 @@ def write_log(log_path, log):
 
 
 def spawn_container(args):
-    gzv, ros, config, pr, confirm, nvidia, source, pull = args
+    gzv, ros, config, pr, confirm, nvidia, source, pull, build = args
     gzv = str(gzv)
     tag_name = "gz" + gzv
     build_args = {"GZV": gzv}
@@ -205,6 +207,8 @@ def spawn_container(args):
         }
         if pull:
             cmd = "gzrepos.sh"
+        elif build:
+            cmd = "gzcolcon.sh"
         else:
             cmd = None
     else:

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from plugins import spawn
 argv = {
     "<gzv>": None, "<ros>": None, "<config>": None, "<pr>": None, "--gzv": None,
     "--ros": None, "--config": None, "--pr": None, "--yes": None,
-    "--nvidia": None, "--source": None, "--pull": None
+    "--nvidia": None, "--source": None, "--pull": None, "--build": None
 }
 
 run_code = {}

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from plugins import spawn
 argv = {
     "<gzv>": None, "<ros>": None, "<config>": None, "<pr>": None, "--gzv": None,
     "--ros": None, "--config": None, "--pr": None, "--yes": None,
-    "--nvidia": None, "--source": None
+    "--nvidia": None, "--source": None, "--pull": None
 }
 
 run_code = {}


### PR DESCRIPTION
These options help the user automatically grab all repos and build Gazebo from source when using the --source option.

Examples:
The entire install from source can be done all at once
`gzdev spawn 9 --source --pull --build`

Or step by step as shown below:

Set up development environment and dependencies:
`gzdev spawn 9 --source`

Pull all the official source code repositories:
`gzdev spawn 9 --pull`

Compile and install everything from source
`gzdev spawn 9 --build`
