### PR TITLE
Add repository plugin: enable/disable/list repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install:
   - pip install -r requirements.txt
 script:
   - pytest -sv test.py
+  - python3 plugins/*_TEST.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# gzdev
+gzdev is a tool that facilitates the development of the open source robotics simulator Gazebo. The tool aims to streamline many of the usual tasks that Gazebo developers face on a daily basis.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ Commands/Plugins:
 	spawn          Spawn a virtual environment ready for development.
 ```
 
+## repository
+```
+System operations to manage extra repositories affecting Gazebo/ROS
+
+Usage:
+	gzdev repository (ACTION) [<repo-name>] [<repo-type>] [--project=<project_name>]
+        gzdev repository list
+	gzdev repository (-h | --help)
+	gzdev repository --version
+Action:
+        enable                  Enable repository in the system
+        disable                 Disable repository (if present)
+        list                    List repositories enabled
+Options:
+	-h --help               Show this screen
+	--version               Show gzdev's version
+"""
+```
+## Basic examples
+`gzdev repository enable osrf prerelease`
+
+## Per project configuration
+Some projects require prerelease or nigthly repositories in order to work in early
+stages.
+
+`gzdev repository enable --project=ignition-math6`
+
 ## spawn
 ```
 Spawn various Gazebo versions and ROS distributions inside docker containers.
@@ -79,6 +106,7 @@ and pip (python2.7 version):
 
 Then the following command will build the docker image, mount the gazebo source code directory into the running container, compile from source, set up the environment, and finally run gazebo  
 `gzdev spawn 9 --source`
+
 
 # Support/Contribute
 * [GitHub Issue Tracker](https://github.com/osrf/gzdev/issues) - gzdev specific questions

--- a/gzdev.py
+++ b/gzdev.py
@@ -16,7 +16,8 @@ Options:
 	--version      Show gzdev's version.
 
 Commands/Plugins:
-	spawn          Spawn a virtual environment ready for development.
+        spawn          Spawn a virtual environment ready for development.
+        repository     Enable/Disable gazebo repositories.
 """
 
 from docopt import docopt
@@ -26,7 +27,8 @@ from sys import stderr
 if __name__ == '__main__':
     args = docopt(__doc__, version='gzdev-core 0.1.0', options_first=True)
     cmd = args['<command>']
-    is_valid = {"spawn": True}
+    is_valid = {"spawn"      : True,
+                "repository" : True}
 
     if is_valid.get(cmd):
         plugin = import_module("plugins." + cmd)

--- a/plugins/config/_test_repository.yaml
+++ b/plugins/config/_test_repository.yaml
@@ -1,0 +1,25 @@
+---
+
+repositories:
+    - name: osrf
+      key: ABC1234567890
+      types:
+          - name: stable
+            url: http://stable
+          - name: prerelease
+            url: http://prerelease
+
+# wildcards are allowed in name, entries are processed in top-down order
+projects:
+    - name: ignition-math6
+      repositories:
+          - name: osrf
+            type: stable
+    - name: ignition-transport7
+      repositories:
+          - name: osrf
+            type: prerelease
+    - name: ignition-.*
+      repositories:
+          - name: osrf
+            type: regexp

--- a/plugins/config/_test_repository.yaml
+++ b/plugins/config/_test_repository.yaml
@@ -18,6 +18,8 @@ projects:
     - name: ignition-transport7
       repositories:
           - name: osrf
+            type: stable
+          - name: osrf
             type: prerelease
     - name: ignition-.*
       repositories:

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -1,5 +1,4 @@
 ---
-
 repositories:
     - name: osrf
       key: D2486D2DD83DB69272AFE98867170598AF249743
@@ -8,20 +7,29 @@ repositories:
             url: http://packages.osrfoundation.org/gazebo/ubuntu-stable
           - name: prerelease
             url: http://packages.osrfoundation.org/gazebo/ubuntu-prerelease
-          - name: prerelease
-            url: http://packages.osrfoundation.org/gazebo/ubuntu-prerelease
+          - name: nightly
+            url: http://packages.osrfoundation.org/gazebo/ubuntu-nightly
 
 # wildcards are allowed in name, entries are processed in top-down order
 projects:
-    - name: ignition-math6
+    - name: ignition-gazebo.*
+      repositories:
+          - name: osrf
+            type: prerelease
+    - name: ignition-launch.*
+      repositories:
+          - name: osrf
+            type: prerelease
+    # generic regexp
+    - name: gazebo.*
       repositories:
           - name: osrf
             type: stable
-    - name: ignition-transport7
-      repositories:
-          - name: osrf
-            type: prerelease
     - name: ignition-.*
       repositories:
           - name: osrf
-            type: prerelease
+            type: stable
+    - name: sdformat.*
+      repositories:
+          - name: osrf
+            type: stable

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -1,0 +1,27 @@
+---
+
+repositories:
+    - name: osrf
+      key: D2486D2DD83DB69272AFE98867170598AF249743
+      types:
+          - name: stable
+            url: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+          - name: prerelease
+            url: http://packages.osrfoundation.org/gazebo/ubuntu-prerelease
+          - name: prerelease
+            url: http://packages.osrfoundation.org/gazebo/ubuntu-prerelease
+
+# wildcards are allowed in name, entries are processed in top-down order
+projects:
+    - name: ignition-math6
+      repositories:
+          - name: osrf
+            type: stable
+    - name: ignition-transport7
+      repositories:
+          - name: osrf
+            type: prerelease
+    - name: ignition-.*
+      repositories:
+          - name: osrf
+            type: prerelease

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -15,9 +15,13 @@ projects:
     - name: ignition-gazebo.*
       repositories:
           - name: osrf
+            type: stable
+          - name: osrf
             type: prerelease
     - name: ignition-launch.*
       repositories:
+          - name: osrf
+            type: stable
           - name: osrf
             type: prerelease
     # generic regexp

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -24,6 +24,7 @@ from os.path import dirname, realpath, isfile, join
 import re
 from subprocess import run, PIPE, CalledProcessError, check_call
 from sys import stderr
+import pathlib
 import platform
 import yaml
 
@@ -43,8 +44,9 @@ def error(msg):
     print("\n" + msg + "\n", file=stderr)
     exit(-1)
 
-def load_config_file(config_file_path = 'plugins/config/repository.yaml'):
-    with open(config_file_path, 'r') as stream:
+def load_config_file(config_file_path = 'config/repository.yaml'):
+    fn = pathlib.Path(__file__).parent / config_file_path
+    with open(str(fn), 'r') as stream:
         try:
             config = yaml.safe_load(stream)
             return config

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -108,8 +108,7 @@ def install_repo(repo_name, repo_type, config):
     full_path = get_sources_list_file_path(repo_name, repo_type)
 
     if isfile(full_path):
-        warn("gzdev file with the repositoy already exists in the system")
-        warn("[" + full_path + "]")
+        warn("gzdev file with the repositoy already exists in the system\n[" + full_path + "]")
         return
 
     install_key(key)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -109,6 +109,7 @@ def install_repo(repo_name, repo_type, config):
 
     if isfile(full_path):
         warn("gzdev file with the repositoy already exists in the system")
+        warn("[" + full_path + "]")
         return
 
     install_key(key)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -95,7 +95,7 @@ def install_key(key):
 def run_apt_update():
     _check_call(['apt-get','update'])
 
-def install_repos(projects_list, config):
+def install_repos(project_list, config):
     for p in project_list:
         install_repo(p['name'], p['type'], config)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -105,7 +105,7 @@ def install_repo(repo_name, repo_type, config):
     full_path = get_sources_list_file_path(repo_name, repo_type)
 
     if isfile(full_path):
-        error("gzdev file with the repositoy already exist in the system")
+        error("gzdev file with the repositoy already exists in the system")
 
     install_key(key)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -145,8 +145,7 @@ def process_input(args, config):
         project_list = load_project(project, config)
 
     if (action == "enable"):
-        install_repos(project_list)
-        install_repo(repo_name, repo_type, config)
+        install_repos(project_list, config)
     elif (action == "disable"):
         disable_repo(repo_name)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -144,11 +144,12 @@ def validate_input(args, config):
 def process_input(args, config):
     action, repo_name, repo_type, project = args
 
-    if project:
-        project_list = load_project(project, config)
-
     if (action == "enable"):
-        install_repos(project_list, config)
+        if project:
+            project_list = load_project(project, config)
+            install_repos(project_list, config)
+        else:
+            install_repo(repo_name, repo_type, config)
     elif (action == "disable"):
         disable_repo(repo_name)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -54,22 +54,15 @@ def load_config_file(config_file_path = 'config/repository.yaml'):
             exit(-1)
 
 def load_project(project, config):
-    repo_name = None
-    repo_type = None
-
     for p in config['projects']:
         pattern = re.compile(p['name'])
         if pattern.search(project):
-           # TODO: support for multiple repositories
-           repo_name = p['repositories'][0]['name']
-           repo_type = p['repositories'][0]['type']
-           # stop in the first match
-           break
+            return p['repositories']
+            # stop in the first match
+            break
 
-    if not repo_name:
-        error("Unknown project: " + project)
+    error("Unknown project: " + project)
 
-    return repo_name, repo_type
 
 def get_platform():
     return platform.linux_distribution()[2]
@@ -101,6 +94,10 @@ def install_key(key):
 
 def run_apt_update():
     _check_call(['apt-get','update'])
+
+def install_repos(projects_list, config):
+    for p in project_list:
+        install_repo(p['name'], p['type'], config)
 
 def install_repo(repo_name, repo_type, config):
     url = get_repo_url(repo_name, repo_type, config)
@@ -145,9 +142,10 @@ def process_input(args, config):
     action, repo_name, repo_type, project = args
 
     if project:
-        repo_name, repo_type = load_project(project, config)
+        project_list = load_project(project, config)
 
     if (action == "enable"):
+        install_repos(project_list)
         install_repo(repo_name, repo_type, config)
     elif (action == "disable"):
         disable_repo(repo_name)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -32,13 +32,12 @@ def _check_call(cmd):
     print('')
     print("Invoking '%s'" % ' '.join(cmd))
     print('')
+    stdout.flush()
 
     try:
         check_call(cmd)
     except Exception as e:
         print(str(e))
-
-    print('')
 
 def error(msg):
     print("\n" + msg + "\n", file=stderr)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -39,8 +39,11 @@ def _check_call(cmd):
         print(str(e))
 
 def error(msg):
-    print("\n" + msg + "\n", file=stderr)
+    print("\n [err] " + msg + "\n", file=stderr)
     exit(-1)
+
+def warn(msg):
+    print("\n [warn] " + msg + "\n", file=stderr)
 
 def load_config_file(config_file_path = 'config/repository.yaml'):
     fn = pathlib.Path(__file__).parent / config_file_path
@@ -105,7 +108,8 @@ def install_repo(repo_name, repo_type, config):
     full_path = get_sources_list_file_path(repo_name, repo_type)
 
     if isfile(full_path):
-        error("gzdev file with the repositoy already exists in the system")
+        warn("gzdev file with the repositoy already exists in the system")
+        return
 
     install_key(key)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -1,0 +1,165 @@
+# Copyright 2018 David Rosa
+# Licensed under the Apache License, Version 2.0
+"""
+Usage:
+	gzdev repository (ACTION) [<repo-name>] [<repo-type>] [--project=<project_name>]
+        gzdev repository list
+	gzdev repository (-h | --help)
+	gzdev repository --version
+
+Action:
+        enable                  Enable repository in the system
+        disable                 Disable repository (if present)
+        list                    List repositories enabled
+
+Options:
+	-h --help               Show this screen
+	--version               Show gzdev's version
+"""
+
+from docopt import docopt
+import imp
+from os import environ
+from os.path import dirname, realpath, isfile, join
+import re
+from subprocess import run, PIPE, CalledProcessError, check_call
+from sys import stderr
+import platform
+import yaml
+
+def _check_call(cmd):
+    print('')
+    print("Invoking '%s'" % ' '.join(cmd))
+    print('')
+
+    try:
+        check_call(cmd)
+    except Exception as e:
+        print(str(e))
+
+    print('')
+
+def error(msg):
+    print("\n" + msg + "\n", file=stderr)
+    exit(-1)
+
+def load_config_file(config_file_path = 'plugins/config/repository.yaml'):
+    with open(config_file_path, 'r') as stream:
+        try:
+            config = yaml.safe_load(stream)
+            return config
+        except yaml.YAMLError as exc:
+            print(exc)
+            exit(-1)
+
+def load_project(project, config):
+    repo_name = None
+    repo_type = None
+
+    for p in config['projects']:
+        pattern = re.compile(p['name'])
+        if pattern.search(project):
+           # TODO: support for multiple repositories
+           repo_name = p['repositories'][0]['name']
+           repo_type = p['repositories'][0]['type']
+           # stop in the first match
+           break
+
+    if not repo_name:
+        error("Unknown project: " + project)
+
+    return repo_name, repo_type
+
+def get_platform():
+    return platform.linux_distribution()[2]
+
+def get_repo_key(repo_name, config):
+    for p in config['repositories']:
+        if p['name'] == repo_name:
+            return p['key']
+
+    error("No key in repo: " + repo_name)
+
+def get_repo_url(repo_name, repo_type, config):
+    for p in config['repositories']:
+        if p['name'] == repo_name:
+            for t in p['types']:
+                if t['name'] == repo_type:
+                    return t['url']
+
+    error("Unknown repository or type: " + repo_name + "/" + repo_type)
+
+
+def get_sources_list_file_path(repo_name, repo_type):
+    filename = "_gzdev_" + repo_name + "_" + repo_type + ".list"
+    directory = "/etc/apt/sources.list.d"
+    return directory + '/' + filename
+
+def install_key(key):
+    _check_call(['apt-key','adv','--keyserver','keyserver.ubuntu.com','--recv-keys', key])
+
+def run_apt_update():
+    _check_call(['apt-get','update'])
+
+def install_repo(repo_name, repo_type, config):
+    url = get_repo_url(repo_name, repo_type, config)
+    key = get_repo_key(repo_name, config)
+    content = "deb " + url + " " + get_platform() + " main"
+    full_path = get_sources_list_file_path(repo_name, repo_type)
+
+    if isfile(full_path):
+        error("gzdev file with the repositoy already exist in the system")
+
+    install_key(key)
+
+    try:
+        f = open(full_path,'w')
+        f.write(content)
+        f.close()
+    except PermissionError:
+        print("No permissiong to install " + full_path + ". Run the script with sudo.")
+
+    run_apt_update()
+
+def disable_repo(repo_name):
+    print("disable feature not implemented yet")
+
+def normalize_args(args):
+    action = args["ACTION"]
+    repo_name = args["<repo-name>"] if args["<repo-name>"] else "osrf"
+    repo_type = args["<repo-type>"] if args["<repo-type>"] else "stable"
+    project = args["--project"]
+
+    return action, repo_name, repo_type, project
+
+def validate_input(args, config):
+    action, repo_name, repo_type, project = args
+
+    if (action == "enable" or action == "disable" or action =="list"):
+        True
+    else:
+        error("Unknown action: " + action)
+
+def process_input(args, config):
+    action, repo_name, repo_type, project = args
+
+    if project:
+        repo_name, repo_type = load_project(project, config)
+
+    if (action == "enable"):
+        install_repo(repo_name, repo_type, config)
+    elif (action == "disable"):
+        disable_repo(repo_name)
+
+def main():
+    try:
+        args = normalize_args(docopt(__doc__, version="gzdev-repository 0.1.0"))
+        config = load_config_file()
+        validate_input(args, config)
+        process_input(args, config)
+    except KeyboardInterrupt:
+        print("spawn was stopped with a Keyboard Interrupt.\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -32,7 +32,6 @@ def _check_call(cmd):
     print('')
     print("Invoking '%s'" % ' '.join(cmd))
     print('')
-    stdout.flush()
 
     try:
         check_call(cmd)

--- a/plugins/repository_TEST.py
+++ b/plugins/repository_TEST.py
@@ -31,18 +31,20 @@ class TestRepo_URL(TestBase):
 
 class TestProjectNameResolution(TestBase):
     def test_direct_match(self):
-        repo_name, repo_type = repository.load_project("ignition-math6", self.config)
-        self.assertEqual(repo_name, 'osrf')
-        self.assertEqual(repo_type, 'stable')
+        projects = repository.load_project("ignition-math6", self.config)
+        for p in projects:
+            self.assertEqual(p['name'], 'osrf')
+            self.assertEqual(p['type'], 'stable')
 
     def test_non_exist(self):
         with self.assertRaises(SystemExit) as cm:
-            repo_name, repo_type = repository.load_project("fooooo", self.config)
+            projects = repository.load_project("fooooo", self.config)
 
     def test_regexp(self):
-        repo_name, repo_type = repository.load_project("ignition-plugin", self.config)
-        self.assertEqual(repo_name, 'osrf')
-        self.assertEqual(repo_type, 'regexp')
+        projects = repository.load_project("ignition-plugin", self.config)
+        for p in projects:
+            self.assertEqual(p['name'], 'osrf')
+            self.assertEqual(p['type'], 'regexp')
 
 
 if __name__ == '__main__':

--- a/plugins/repository_TEST.py
+++ b/plugins/repository_TEST.py
@@ -3,7 +3,7 @@ import repository
 
 class TestBase(unittest.TestCase):
     def setUp(self):
-        self.config = repository.load_config_file('plugins/config/_test_repository.yaml')
+        self.config = repository.load_config_file('config/_test_repository.yaml')
 
 class TestBasicOperations(TestBase):
     def test_config_file_path(self):

--- a/plugins/repository_TEST.py
+++ b/plugins/repository_TEST.py
@@ -1,0 +1,50 @@
+import unittest
+import repository
+
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        self.config = repository.load_config_file('plugins/config/_test_repository.yaml')
+
+class TestBasicOperations(TestBase):
+    def test_config_file_path(self):
+        self.assertTrue(self.config)
+
+class TestRepoKey(TestBase):
+    def test_basic_ok(self):
+        self.assertEqual(
+                repository.get_repo_key('osrf', self.config),
+                'ABC1234567890')
+
+class TestRepo_URL(TestBase):
+    def test_basic_ok(self):
+        self.assertEqual(
+                repository.get_repo_url('osrf','prerelease', self.config),
+                'http://prerelease')
+
+    def test_no_repo(self):
+        with self.assertRaises(SystemExit) as cm:
+            repository.get_repo_url('invalid_repo','invalid_type', self.config)
+
+    def test_no_type(self):
+        with self.assertRaises(SystemExit) as cm:
+            repository.get_repo_url('osrf','invalid_tye', self.config)
+
+class TestProjectNameResolution(TestBase):
+    def test_direct_match(self):
+        repo_name, repo_type = repository.load_project("ignition-math6", self.config)
+        self.assertEqual(repo_name, 'osrf')
+        self.assertEqual(repo_type, 'stable')
+
+    def test_non_exist(self):
+        with self.assertRaises(SystemExit) as cm:
+            repo_name, repo_type = repository.load_project("fooooo", self.config)
+
+    def test_regexp(self):
+        repo_name, repo_type = repository.load_project("ignition-plugin", self.config)
+        self.assertEqual(repo_name, 'osrf')
+        self.assertEqual(repo_type, 'regexp')
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docker==3.4.0
 docopt==0.6.2
 pytest==3.6.2
-yaml
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docker==3.4.0
 docopt==0.6.2
 pytest==3.6.2
+yaml


### PR DESCRIPTION
Usage can be found in the [README file](https://github.com/osrf/gzdev/blob/e142b472eaec895b7ced7fe538f106fff04d72b7/README.md)

Some pending features:
 * Add expire clause to configuration file in order to install prerelease/nightly repository only during a given period of time
 * Avoid to install the repository key twice is the project is using two repositories with the same key
 * Add ROS repositories to the configuration file
 * Implemente the `list` and `disable`actions