### PR TITLE
gazebo11: use prereleases

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -25,6 +25,12 @@ repositories:
 # first entry matching the name is used
 projects:
     # custom projects
+    - name: gazebo11
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
     - name: ignition-tools1
       repositories:
           - name: osrf


### PR DESCRIPTION
cc @j-rivero 

needed by https://bitbucket.org/osrf/gazebo/pull-requests/3161/require-ign-msgs5-51-and-use-ignition-msgs/diff