### PR TITLE
Use prerelease + nightly repositories in new Dome libraries

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -31,6 +31,71 @@ projects:
             type: stable
           - name: osrf
             type: prerelease
+    # Use prerelease + nightly in all dome new major versions
+    - name: ignition-gazebo4
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-fuel-tools5
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-gui4
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-physics3
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-rendering4
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-sensors4
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-transport9
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+    - name: ignition-launch3
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
 
     # generic regexp
     - name: gazebo.*


### PR DESCRIPTION
This should fix https://github.com/ignition-tooling/release-tools/issues/240 and help to keep CI working for the rest of libraries that expect to find sdformat10, which is in the prerelease repository. (i.e.: https://github.com/ignitionrobotics/ign-gazebo/pull/244)