### PR TITLE
Add distro to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+distro
 docker==3.4.0
 docopt==0.6.2
 pytest==3.6.2


### PR DESCRIPTION
This indirectly should fix focal support on those system that does not have distro installed.