### PR TITLE
ignition-physics2: use prerelease for now

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -31,6 +31,12 @@ projects:
             type: stable
           - name: osrf
             type: prerelease
+    # needs sdformat 9.3 prerelease, remove after 9.3 stable release
+    - name: ignition-physics2
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
     # Use prerelease + nightly in all dome new major versions
     - name: ignition-gazebo4
       repositories:


### PR DESCRIPTION
https://github.com/ignitionrobotics/ign-physics/pull/86 needs prerelease version of sdformat 9.3.0. Revert this after stable release of sdformat 9.3.0.