### PR TITLE
gazebo11: use prerelease for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
 script:
   - pytest -sv test.py
   - python3 plugins/*_TEST.py
+  - python3 gzdev.py repository list

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -32,6 +32,11 @@ projects:
           - name: osrf
             type: prerelease
     # needs sdformat 9.3 prerelease, remove after 9.3 stable release
+    - name: gazebo11
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
     - name: ignition-physics2
       repositories:
           - name: osrf

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -33,6 +33,7 @@ projects:
             type: prerelease
     # needs sdformat 9.3 prerelease, remove after 9.3 stable release
     - name: gazebo11
+      repositories:
           - name: osrf
             type: stable
           - name: osrf


### PR DESCRIPTION
https://github.com/osrf/gazebo/pull/2824 needs prerelease version of sdformat 9.3.0. Revert this after stable release of sdformat 9.3.0.

This also adds a CI test for yaml syntax to fix #17. There is a syntax error in 410d0e6, CI fails after adding the check, and yaml syntax is then fixed in 4726492.